### PR TITLE
Minor PSF grid improvements

### DIFF
--- a/winnie/convolution.py
+++ b/winnie/convolution.py
@@ -94,7 +94,7 @@ def psf_convolve_cpu(im, psf_im):
     return imcon
 
 
-def generate_lyot_psf_grid(inst, source_spectrum=None, nr=12, ntheta=4, log_rscale=True, rmin=0.05, rmax=3.5, shift=None, osamp=2, fov_pixels=201, show_progress=True):
+def generate_lyot_psf_grid(inst, source_spectrum=None, nr=12, ntheta=4, log_rscale=True, rmin=0.05, rmax=3.5, normalize='exit_pupil', shift=None, osamp=2, fov_pixels=201, show_progress=True):
     
     """
     Creates a grid of synthetic PSFs using a WebbPSF NIRCam or MIRI WebbPSF object. The spatial sampling used here is not appropriate for MIRI FQPM data. 
@@ -125,6 +125,10 @@ def generate_lyot_psf_grid(inst, source_spectrum=None, nr=12, ntheta=4, log_rsca
 
         rmax: float
             The maximum radial separation in arcseconds from the coronagraph center to use for the PSF grid.
+
+        normalize: str
+            The normalization to use for the PSFs. Options are 'exit_pupil' (default), 'first', and 'last' 
+            (see WebbPSF documentation for more info).
 
         shift: ndarray
             The detector sampled shift (in pixels) needed to place the PSF as the geometric center of the array.
@@ -190,7 +194,7 @@ def generate_lyot_psf_grid(inst, source_spectrum=None, nr=12, ntheta=4, log_rsca
     for psf_offset in iterator:
         inst_grid.options['coron_shift_x'] = -psf_offset[0]
         inst_grid.options['coron_shift_y'] = -psf_offset[1]
-        psf = inst_grid.calc_psf(source=source_spectrum, fov_pixels=fov_pixels, oversample=osamp, normalize='exit_pupil')[2].data
+        psf = inst_grid.calc_psf(source=source_spectrum, fov_pixels=fov_pixels, oversample=osamp, normalize=normalize)[2].data
         psfs.append(psf)
     psfs = np.array(psfs)
     
@@ -201,7 +205,7 @@ def generate_lyot_psf_grid(inst, source_spectrum=None, nr=12, ntheta=4, log_rsca
     field_rot = 0 if inst._rotation is None else inst._rotation
     
     psf_offsets_polar = np.array([rvals_all, thvals_all-field_rot])
-    psf_offsets = webbpsf_ext.coords.rtheta_to_xy(*psf_offsets_polar)
+    psf_offsets = np.array(webbpsf_ext.coords.rtheta_to_xy(*psf_offsets_polar))
     
     return psfs, psf_offsets_polar, psf_offsets
 

--- a/winnie/space.py
+++ b/winnie/space.py
@@ -357,7 +357,7 @@ class SpaceRDI:
             an error will be raised.
         """
         if self.concat is None:
-            raise AttributeError("""Prior to executing "run_rdi", you must load a
+            raise ValueError("""Prior to executing "run_rdi", you must load a
             concatenation using the load_concat method.""")
         
         output_ext = copy(self.output_ext)
@@ -586,14 +586,15 @@ class SpaceRDI:
                             recalc_psf_grid=False, psf_grid_kwargs={}, psfgrids_output_dir='psfgrids',
                             fetch_opd_by_date=True):
 
-        if self.convolver is None:
+        convolver_args = dict(reference_index=reference_index, coron_offsets=coron_offsets, fov_pixels=fov_pixels, osamp=osamp, output_ext=output_ext,
+                                            prefetch_psf_grid=prefetch_psf_grid, recalc_psf_grid=recalc_psf_grid, psf_grid_kwargs=psf_grid_kwargs)
+        
+        if self.convolver is None or convolver_args != self.convolver_args: # If the convolver is not already set up or the args have changed
             self.convolver = SpaceConvolution(database=self.database, source_spectrum=source_spectrum, ncores=self.ncores, use_gpu=self.use_gpu,
                                               verbose=self.verbose, show_plots=self.show_plots, show_progress=True, overwrite=self.overwrite,
                                               psfgrids_output_dir=psfgrids_output_dir, fetch_opd_by_date=fetch_opd_by_date, pad_data=self.pad_data)
+            self.convolver_args = convolver_args
 
-            self.convolver_args = dict(reference_index=reference_index, coron_offsets=coron_offsets, fov_pixels=fov_pixels, osamp=osamp, output_ext=output_ext,
-                                            prefetch_psf_grid=prefetch_psf_grid, recalc_psf_grid=recalc_psf_grid, psf_grid_kwargs=psf_grid_kwargs)
-                                            
         if self.concat != self.convolver.concat:
             self.convolver.load_concat(self.concat, cropped_shape=self.cropped_shape, **self.convolver_args)
         pass 


### PR DESCRIPTION
- The prepare_convolution method for winnie.SpaceRDI now reinitializes the SpaceConvolution instance if one of the arguments in convolver_args has changed. Previously, prepare_convolution only checked if a convolver was defined, not if the requested convolver was defined. 

- 'normalize' can now be set in psf_grid_kwargs when calling prepare_convolution to change the webbpsf normalization behavior.

- winnie.convolution.generate_lyot_psf_grid now returns psf_offsets as a 2D array rather than a tuple of 1D arrays (for consistency with the format resulting from reading in a previously computed grid).

