### PR TITLE
Fix psfmask cache check: compare np.shape() tuple against a tuple, not a list

### DIFF
--- a/winnie/space.py
+++ b/winnie/space.py
@@ -356,7 +356,7 @@ class SpaceRDI:
 
         if self.save_coron_transmission:
             outfile = self.output_dir + self.concat + '_psfmask.fits'
-            if not os.path.exists(outfile) or np.shape(fits.getdata(outfile)) != [self.ny, self.nx]:
+            if not os.path.exists(outfile) or np.shape(fits.getdata(outfile)) != (self.ny, self.nx):
                 _ = self.make_derot_coron_maps(collapse_rolls=False, save_products=True)
 
 


### PR DESCRIPTION
### Problem
In `SpaceRDI.load_concat` (`winnie/space.py:359`), the psfmask cache check compares `np.shape()` (a tuple) against a list:
```python
if not os.path.exists(outfile) or np.shape(fits.getdata(outfile)) != [self.ny, self.nx]:
    _ = self.make_derot_coron_maps(collapse_rolls=False, save_products=True)
```

np.shape() always returns a tuple, so comparing it against a list was always True, causing make_derot_coron_maps to regenerate the psfmask on every load_concat call instead of reusing a valid cached file.

### Fix

Compare against a tuple:

```python
if not os.path.exists(outfile) or np.shape(fits.getdata(outfile)) != (self.ny, self.nx):
```